### PR TITLE
GT Upgrade swift package versions

### DIFF
--- a/Example/OAuthExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/OAuthExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/keychain-password-store-ios.git",
       "state" : {
-        "revision" : "86cd292171151f81cc58b59cd24321d2382f1594",
-        "version" : "1.0.0"
+        "revision" : "47035f6928732295138b9cbf4cc8dec17dc0b2e4",
+        "version" : "1.0.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/request-operation-ios.git",
       "state" : {
-        "revision" : "9b222164f89e8437cb985640da979687bbb7b919",
-        "version" : "1.2.1"
+        "revision" : "2e8820337c0ba37eb542893ce67eb1a0408b5760",
+        "version" : "1.3.1"
       }
     }
   ],

--- a/Example/OAuthExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/OAuthExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/keychain-password-store-ios.git",
       "state" : {
-        "revision" : "47035f6928732295138b9cbf4cc8dec17dc0b2e4",
-        "version" : "1.0.2"
+        "revision" : "d5b628d64147828e305bcf4bb1fffacf9ce56a5c",
+        "version" : "1.0.3"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/request-operation-ios.git",
       "state" : {
-        "revision" : "2e8820337c0ba37eb542893ce67eb1a0408b5760",
-        "version" : "1.3.1"
+        "revision" : "f6eb9f04084049adcee9c19e95308df3998eeedd",
+        "version" : "1.3.2"
       }
     }
   ],

--- a/OAuth.podspec
+++ b/OAuth.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name             = 'OAuth'
-    s.version          = '1.2.0'
+    s.version          = '1.2.1'
     s.summary          = 'Generic OAuth implementation using PKCE flow and ASWebAuthenticationSession.'
   
   

--- a/OAuth.podspec
+++ b/OAuth.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/**/*.{swift}'  
 	
     s.dependency 'OktaOidc', '~> 3.11.2'
-    s.dependency 'RequestOperation', '~> 1.3.1' 
-    s.dependency 'KeychainPasswordStore', '~> 1.0.2' 
+    s.dependency 'RequestOperation', '~> 1.3.2' 
+    s.dependency 'KeychainPasswordStore', '~> 1.0.3' 
   end
   

--- a/OAuth.podspec
+++ b/OAuth.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/**/*.{swift}'  
 	
     s.dependency 'OktaOidc', '~> 3.11.2'
-    s.dependency 'RequestOperation', '~> 1.2.1' 
-    s.dependency 'KeychainPasswordStore', '~> 1.0.0' 
+    s.dependency 'RequestOperation', '~> 1.3.1' 
+    s.dependency 'KeychainPasswordStore', '~> 1.0.2' 
   end
   

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "keychain-password-store-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CruGlobal/keychain-password-store-ios.git",
+      "state" : {
+        "revision" : "47035f6928732295138b9cbf4cc8dec17dc0b2e4",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "okta-oidc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/okta/okta-oidc-ios.git",
+      "state" : {
+        "revision" : "91eac722b8e859ba7f15d65a9085a64a296bc065",
+        "version" : "3.11.2"
+      }
+    },
+    {
+      "identity" : "request-operation-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CruGlobal/request-operation-ios.git",
+      "state" : {
+        "revision" : "2e8820337c0ba37eb542893ce67eb1a0408b5760",
+        "version" : "1.3.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/keychain-password-store-ios.git",
       "state" : {
-        "revision" : "47035f6928732295138b9cbf4cc8dec17dc0b2e4",
-        "version" : "1.0.2"
+        "revision" : "d5b628d64147828e305bcf4bb1fffacf9ce56a5c",
+        "version" : "1.0.3"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CruGlobal/request-operation-ios.git",
       "state" : {
-        "revision" : "2e8820337c0ba37eb542893ce67eb1a0408b5760",
-        "version" : "1.3.1"
+        "revision" : "f6eb9f04084049adcee9c19e95308df3998eeedd",
+        "version" : "1.3.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/okta/okta-oidc-ios.git", .upToNextMinor(from: "3.11.2")),
-        .package(url: "https://github.com/CruGlobal/request-operation-ios.git", .upToNextMinor(from: "1.3.1")),
-        .package(url: "https://github.com/CruGlobal/keychain-password-store-ios.git", .upToNextMinor(from: "1.0.2"))
+        .package(url: "https://github.com/CruGlobal/request-operation-ios.git", .upToNextMinor(from: "1.3.2")),
+        .package(url: "https://github.com/CruGlobal/keychain-password-store-ios.git", .upToNextMinor(from: "1.0.3"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/okta/okta-oidc-ios.git", .upToNextMinor(from: "3.11.2")),
-        .package(url: "https://github.com/CruGlobal/request-operation-ios.git", .upToNextMinor(from: "1.2.1")),
-        .package(url: "https://github.com/CruGlobal/keychain-password-store-ios.git", .upToNextMinor(from: "1.0.0"))
+        .package(url: "https://github.com/CruGlobal/request-operation-ios.git", .upToNextMinor(from: "1.3.1")),
+        .package(url: "https://github.com/CruGlobal/keychain-password-store-ios.git", .upToNextMinor(from: "1.0.2"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
                 .product(name: "RequestOperation", package: "request-operation-ios"),
                 .product(name: "KeychainPasswordStore", package: "keychain-password-store-ios")
             ],
-            exclude: ["Example"]),
+            exclude: ["../../Example"]),
         .testTarget(
             name: "OAuthTests",
             dependencies: ["OAuth"]),

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Steps to publish new versions for Cocoapods and Swift Package Manager.
 
 - Edit Oauth.podspec s.version to the newly desired version following Major.Minor.Patch.
 
-- Run command 'pod lib lint Oauth.podspec' to ensure it can deploy without any issues (https://guides.cocoapods.org/making/using-pod-lib-create.html#deploying-your-library).
+- Run command 'pod lib lint OAuth.podspec --private --verbose --sources=https://github.com/CruGlobal/cocoapods-specs.git,https://cdn.cocoapods.org/' to ensure it can deploy without any issues (https://guides.cocoapods.org/making/using-pod-lib-create.html#deploying-your-library).
 
 - Merge the s.version change into the main branch and then tag the main branch with the new version and push the tag to remote (Swift Package Manager relies on tags).  
 
-- Run command 'pod repo push cruglobal-cocoapods-specs Oauth.podspec' to push to CruGlobal cocoapods specs (https://github.com/CruGlobal/cocoapods-specs).  You can also run command 'pod repo list' to see what repos are currently added and 'pod repo add cruglobal-cocoapods-specs https://github.com/CruGlobal/cocoapods-specs.git' to add repos (https://guides.cocoapods.org/making/private-cocoapods.html).
+- Run command 'pod repo push cruglobal-cocoapods-specs --private --verbose --sources=https://github.com/CruGlobal/cocoapods-specs.git,https://cdn.cocoapods.org/' to push to CruGlobal cocoapods specs (https://github.com/CruGlobal/cocoapods-specs).  You can also run command 'pod repo list' to see what repos are currently added and 'pod repo add cruglobal-cocoapods-specs https://github.com/CruGlobal/cocoapods-specs.git' to add repos (https://guides.cocoapods.org/making/private-cocoapods.html).
 
 
 Cru Global Specs Repo: https://github.com/CruGlobal/cocoapods-specs

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-# OAuth
+OAuth
+=====
 
 This module implements OAuth with a PKCE flow and ASWebAuthenticationSession.  It is configurable for authorizing, fetching access and refresh tokens, and persisting tokens to the device keychain.
+
+- [Publishing New Versions](#publishing-new-versions)
+
+
+### Publishing New Versions
+
+Steps to publish new versions for Cocoapods and Swift Package Manager. 
+
+- Edit Oauth.podspec s.version to the newly desired version following Major.Minor.Patch.
+
+- Run command 'pod lib lint Oauth.podspec' to ensure it can deploy without any issues (https://guides.cocoapods.org/making/using-pod-lib-create.html#deploying-your-library).
+
+- Merge the s.version change into the main branch and then tag the main branch with the new version and push the tag to remote (Swift Package Manager relies on tags).  
+
+- Run command 'pod repo push cruglobal-cocoapods-specs Oauth.podspec' to push to CruGlobal cocoapods specs (https://github.com/CruGlobal/cocoapods-specs).  You can also run command 'pod repo list' to see what repos are currently added and 'pod repo add cruglobal-cocoapods-specs https://github.com/CruGlobal/cocoapods-specs.git' to add repos (https://guides.cocoapods.org/making/private-cocoapods.html).
+
+
+Cru Global Specs Repo: https://github.com/CruGlobal/cocoapods-specs
+
+Private Cocoapods: https://guides.cocoapods.org/making/private-cocoapods.html


### PR DESCRIPTION
- Update Swift Version to 5.7
- Update ReadMe to include instructions on publishing new versions
- Exclude Example project in Swift Package
- Upgrade dependency versions